### PR TITLE
change workers to 0 in puma.rb to boot puma in single mode

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -25,7 +25,7 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+workers ENV.fetch("WEB_CONCURRENCY") { 0 }
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code


### PR DESCRIPTION
## Config PUMA
Après une profonde enquête de **Pierre**, j'ai changé les workers à 0 dans puma.rb pour forcer le lancement de PUMA en single mode. 
Cela permet le bon fonctionnement du broadcast
```rb
workers ENV.fetch("WEB_CONCURRENCY") { 0 }
```