### PR TITLE
remove O workers and comment the origin line

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -25,7 +25,7 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-workers ENV.fetch("WEB_CONCURRENCY") { 0 }
+# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code


### PR DESCRIPTION
### Essai pour débugger Sidekiq en prod

j'ai remis les workers à 2 dans la config puma: mais j'ai commenté la ligne
```rb 
# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
```
c'est la config qu'il y avait dans nos autres projets : Pet me etc...

Avec cette modif, Puma demarre toujours en **single mode** en local