### PR TITLE
fix styles on best scores dashboard

### DIFF
--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -4,7 +4,7 @@
     background: linear-gradient(-45deg, #ee7752, #e73c7e, #23a6d5, #23d5ab);
     background-size: 400% 400%;
     animation: gradient 5s ease infinite;
-    height: 100vh;
+    min-height: 100vh;
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/app/assets/stylesheets/pages/_showuser.scss
+++ b/app/assets/stylesheets/pages/_showuser.scss
@@ -18,22 +18,110 @@
  color: #bc4e9c;
 }
 
-.highscore {
-  // background-color: #bc4e9c;
+.scores-card {
   box-sizing: border-box;
   width: 80%;
   max-width: 500px;
-  color: white;
+  padding: 0px;
+  margin-bottom: 2em;
+  border-radius: 20px;
+  border: 1px solid white;
+
+  & h4 {
+    font-weight: bold;
+    background-color: white;
+    color: black;
+    padding: 10px;
+    border-top-left-radius: 20px;
+    border-top-right-radius: 20px;
+    mix-blend-mode: color-dodge;
+    background-clip: border;
+    text-align: center;
+  }
+
+  & p {
+    color: white;
+    margin-bottom: 5px;
+  }
+  & a {
+      color: black;
+      background-color: white;
+      border-radius: 10px;
+      padding: 2px 8px 3px 6px;
+      mix-blend-mode: color-dodge;
+      text-decoration: none;
+      border: 1px solid white;
+
+      &:hover {
+        color: white;
+        background: none;
+      }
+    }
+}
+
+#ranking {
+  display: flex;
+  justify-content: center;
+
+  & th {
+    width: 1em;
+    text-align: center;
+    font-size: 1.5em;
+    font-weight: bold;
+  }
+  & td {
+    font-size: 1.3em;
+    padding: 0 1em;
+    &.pseudo-ranking {
+    width: 50%;
+    }
+    &.playlist-ranking {
+    width: 20%;
+    margin: 0 1em;
+    text-align: right;
+    }
+    &.score-ranking {
+    font-weight: bold;
+    text-align: right;
+    }
+  }
+}
+
+#time-ranking {
+  display: flex;
+  justify-content: center;
+
+  & dt{
+    font-size: 1.3em;
+    font-weight: 400;
+    padding-bottom: 1.3em;
+
+    & b {
+      font-size: 1.5em;
+      font-weight: bold;
+    }
+  }
+  & dd {
+    text-align: center;
+    font-size: 1.3em;
+    font-style: normal;
+    line-height: 1.2em;
+  }
+  }
+/*
+.highscore {
+  box-sizing: border-box;
+  width: 80%;
+  max-width: 500px;
   padding: 40px;
   border-radius: 20px;
   margin-bottom: 10px;
-  // box-shadow: 0 0 5px #bc4e9c;
   border: 1px solid white;
+  color: white;
     & p {
       font-size: 1.3em;
     }
     & a {
-      // color: #bc4e9c;
       color: black;
       background-color: white;
       border-radius: 10px;
@@ -56,6 +144,7 @@
 .highscore-score {
   font-weight: bolder;
 }
+*/
 
 .statperso {
   //background-color: white;
@@ -71,49 +160,54 @@
   padding: 10px 50px;
 }
 
-.item-stat {
-  // background-color: #bc4e9c;
-  background-color: white;
-  color: white;
-  margin: 1em 0.5em;
-  border-radius: 50%;
-  height: 60px;
-  width: 60px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  color: black;
-  font-weight: bold;
-  mix-blend-mode: color-dodge;
-  & p {
-    margin-bottom: 0;
-  }
-}
-
 ul.list-stats {
   padding: 1em 0.5em;
   margin: 1em;
-  display: flex;
+  display: inline-flex;
   flex-direction: column;
   align-items: center;
   justify-content: space-around;
   border: 1px solid white;
   border-radius: 20px;
-
 }
+
 .list-stats li{
   padding: 0;
   list-style: none;
+  font-family: Arial;
+  color: white;
+  margin: 0.5em 0.5em;
+  & i {
+    text-align: center;
+  }
+  &.description {
+    font-size: 1.2em;
+    text-align: center;
+  }
+  &.item-stat {
+    font-weight: bold;
+    //background-color: white;
+    // border-radius: 50%;
+    height: 60px;
+    width: 100%;
+    //display: flex;
+    //justify-content: center;
+    //align-items: center;
+    & h1, h2 {
+      text-align: center;
+      margin-bottom: 0;
+    }
+  }
 }
 
+
+
 .percent-card {
-  // border: 1px solid #bc4e9c;
   border: 1px solid white;
   padding: 0px;
   width: 85px;
   border-radius: 20px;
   & h6 {
-    // background-color: #bc4e9c;
     font-weight: bold;
     background-color: white;
     color: black;
@@ -121,10 +215,9 @@ ul.list-stats {
     border-top-left-radius: 20px;
     border-top-right-radius: 20px;
     mix-blend-mode: color-dodge;
-
+    background-clip: border;
   }
   & p {
-    // color: #bc4e9c;
     color: white;
     margin-bottom: 5px;
   }

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -23,35 +23,48 @@
   </div>
 
   <!--<div class="container-showuser">-->
-    <div class="highscore">
-      <h3 class="text-center mb-5">Top Scores</h3>
-      <div id="ranking" class="mb-3">
+  <div id="highscore" class="scores-card">               <!-- Affiche les 3 meilleurs scores -->
+    <h4>Meilleurs scores ever</h4>
+    <div id="ranking" class="p-3">
       <% ranking = 1 %>
       <% if Game.count != 0 %>
-        <% Game.order(total_score: :desc).first(3).each do |game| %>
-        <div class="d-flex justify-content-between">
-          <h4 class="px-2"><%= ranking %>.</h4>
-          <p class ="mx-2 mr-auto"><%= link_to "#{game.user.pseudo}", user_path(game.user) %></p>
-          <p class="highscore-playlist"><%= game.playlist.name %></p>
-          <p class="highscore-score ml-3"><%= game.total_score %></p>
-          <% ranking += 1 %>
-        </div>
-      <% end %>
+        <table>
+          <tbody>
+            <% Game.order(total_score: :desc).first(3).each do |game| %>
+              <tr>
+                <th><%= ranking %></th>
+                <td class='pseudo-ranking'><%= link_to "#{game.user.pseudo}", user_path(game.user) %></td>
+                <td class='score-ranking'><%= game.total_score %></td>
+                <td class='playlist-ranking'><%= game.playlist.name %></td>
+              </tr>
+              <% ranking += 1 %>
+            <% end %>
+            </tbody>
+          </table>
       <% else %>
       <p>1</p>
       <p>2</p>
       <p>3</p>
       <% end %>
-      </div>
+    </div>
+  </div>
 
-      <h3 class="text-center">Le + rapide</h3>
-      <div class="d-flex justify-content-between mx-3">
+    <div class="scores-card">
+      <h4>Meilleur temps ever</h4>   <!-- Affiche le meilleur temps -->
+      <div id="time-ranking" class="p-3">
         <% if Answer.count != 0 %>
-        <p><%= link_to "#{@faster_answer.user.pseudo}", user_path(@faster_answer.user) %></p>
-        <p class="text-justify px-2"><%= @faster_answer.track.artist %> / <%= @faster_answer.track.title %></p>
-        <p><%= @faster_answer.answering_time %>s</p>
-        <% else %>
-        <p>-</p>
+          <dl>
+            <dt><%= link_to "#{@faster_answer.user.pseudo}", user_path(@faster_answer.user) %> a trouvé en <b><%= @faster_answer.answering_time %> s</b></dt>
+            <dd><em><%= @faster_answer.track.title %></em></dd><dd><strong><%= @faster_answer.track.artist %>.</strong></dd>
+          </dl>
+          <!--
+          <p class="d-flex justify-content-between mx-3">
+            <span><%#= link_to "#{@faster_answer.user.pseudo}", user_path(@faster_answer.user) %></span>
+            <span><%#= @faster_answer.answering_time %> s</span>
+          </p>
+          <p class="text-justify px-2"><%#= @faster_answer.track.artist %> / <%#= @faster_answer.track.title %></p>
+          --><% else %>
+          <p>-</p>
         <% end %>
 
       </div>
@@ -61,43 +74,50 @@
       <!-- <h3>pourcentage de bonnes réponse</h3> -->
       <div class="d-flex flex-column justify-content-between resume">
       <div class="d-flex flex-row justify-content-center mb-5">
-        <ul class="list-stats">
-          <li><i class="fas fa-trophy fa-2x"></i><li>
 
-          <li><div class="item-stat">
-            <% if @user.games.count != 0 %>
-            <p><%= @user_hight_score %></p>
-            <% else %>
-            <p>-</p>
-            <% end %>
-          </div>
+        <ul class="list-stats">
+          <li>
+            <i class="fas fa-trophy fa-2x"></i>
           </li>
+
+          <li class="item-stat ">
+            <% if @user.games.count != 0 %>
+              <h2><%= @user_hight_score %></h2>
+            <% else %>
+              <h2>-</h2>
+            <% end %>
+          </li>
+
+          <li class="description">Ton best score</li>
         </ul>
 
         <ul class="list-stats">
           <li><i class="fas fa-check fa-2x"></i><li>
-
-          <li><div class="item-stat">
-            <% if @user.games.count != 0 %>
-            <p><%= @percent_user_good_answers %></p>
-            <% else %>
-            <p>-</p>
-            <% end %>
-          </div>
+          <li class="item-stat">
+              <% if @user.games.count != 0 %>
+                  <h2><%= @percent_user_good_answers %> %</h2>
+                <% else %>
+                  <h1>-</h1>
+              <% end %>
           </li>
+          <li class="description">de bonnes réponses</li>
+
         </ul>
 
         <ul class="list-stats">
-          <li><i class="fas fa-stopwatch fa-2x"></i><li>
-
-          <li><div class="item-stat">
-            <% if @user.games.count != 0 %>
-            <p><%= @user_faster_answer.answering_time %></p>
-            <% else %>
-            <p>-</p>
-            <% end %>
-          </div>
+          <li>
+            <i class="fas fa-stopwatch fa-2x"></i>
           </li>
+
+          <li class="item-stat">
+            <% if @user.games.count != 0 %>
+              <h2><%= @user_faster_answer.answering_time %>s</h2>
+            <% else %>
+              <h2>-</h2>
+            <% end %>
+          </li>
+          <li class="description">best chrono</li>
+
         </ul>
       </div>
 


### PR DESCRIPTION
Dashboard : 
retravaillé la mise en page et graphisme pour améliorer la lisibilité et la hiérarchie des infos, unifier la page et limiter le morcellement des données.
- bug de hauteur de page fixé (vérifie sur ton smartphone)
- ce principe de pavés homogènes fonctionne assez bien. 
- J'ai rajouté du texte pour qu'un utilisateur extérieur comprenne mieux de quelles données il s'agit. Textes sans doute à améliorer.
- créé un tableau pour les 'best scores ever' pour un affichage 'carré'.
- aréré les détails de 'Meilleurs temps ever'
- apporté un descriptif aux icônes.
- je propose (pas encore fait) de remonter le <%= if %> en amont de chaque pavé, de sorte que si la donnée est nil, le pavé ne s'affiche pas (par si j'ai essayé deux playlists, seules ces deux vont s'afficher, par ex à 40% 60 % et pas les autres).